### PR TITLE
Enable FireWatir::Firefox#wait_until

### DIFF
--- a/firewatir/lib/firewatir/firefox.rb
+++ b/firewatir/lib/firewatir/firefox.rb
@@ -981,4 +981,9 @@ module FireWatir
     end
 
   end # Firefox
+
+  # Wait until passed block returns true
+  def wait_until(*args)
+    Watir::Waiter.wait_until(*args) {yield}
+  end
 end # FireWatir


### PR DESCRIPTION
Please find below a patch to utilize Watir's wait_until function.

Thank you,
Alan Shields
