### PR TITLE
Legal attribute name fix

### DIFF
--- a/firewatir/lib/firewatir/element.rb
+++ b/firewatir/lib/firewatir/element.rb
@@ -91,12 +91,16 @@ module FireWatir
       when "url", "href", "src", "action", "name"
         return_value = js_eval_method("getAttribute(\"#{attribute_name}\")")
       else
-        jssh_command = "var attribute = '';
-          if(#{element_object}.#{attribute_name} != undefined)
-              attribute = #{element_object}.#{attribute_name};
-          else
-              attribute = #{element_object}.getAttribute(\"#{attribute_name}\");
-          attribute;"
+        if valid_js_identifier? attribute_name
+          jssh_command = "var attribute = '';
+             if(#{element_object}.#{attribute_name} != undefined)
+                 attribute = #{element_object}.#{attribute_name};
+             else
+                 attribute = #{element_object}.getAttribute(\"#{attribute_name}\");
+             attribute;"
+        else
+          jssh_command = "var attribute = ''; attribute = #{element_object}.getAttribute(\"#{attribute_name}\"); attribute;"
+        end
         return_value = js_eval(jssh_command)
       end
       if attribute_name == "value"

--- a/firewatir/lib/firewatir/jssh_socket.rb
+++ b/firewatir/lib/firewatir/jssh_socket.rb
@@ -1,4 +1,11 @@
 module JsshSocket
+  # Determine if str is a valid identifier in Javascript
+  # This is NOT a full validation - it will mess up on unicode. Sorry.
+  # See Section 7.6 of the ECMA-262 spec
+  def valid_js_identifier?(str)
+    /\A[a-z$_][a-z0-9]*\Z/i.match(str)
+  end
+
   # Evaluate javascript and return result. Raise an exception if an error occurred.
   def js_eval(str)
     str.gsub!("\n", "")

--- a/firewatir/unittests/bug_fixes_test.rb
+++ b/firewatir/unittests/bug_fixes_test.rb
@@ -103,6 +103,11 @@ class TC_Bugs< Test::Unit::TestCase
         assert_false(browser.contains_text(/pass/))
     end
 
+    def test_attribute_name_fails_with_hyphen
+      goto_page("div.html")
+      assert("attribute2", browser.div(:id, "div1").attribute("data-html5-attribute"))
+    end
+
     tag_method :test_frame_bug_21, :fails_on_ie
     def test_frame_bug_21
         goto_page("frame_buttons.html")

--- a/firewatir/unittests/html/div.html
+++ b/firewatir/unittests/html/div.html
@@ -8,7 +8,7 @@
 		CVS Revision: "$Revision: 1.0 $"
 		<br>
 		<br>
-		<div id="div1" title="Test1" attribute="attribute" ondblclick="javascript: window.location.href='pass.html';">This text is in a div with an id of div1 and title of test1</div>
+		<div id="div1" title="Test1" attribute="attribute" data-html5-attribute="attribute2" ondblclick="javascript: window.location.href='pass.html';">This text is in a div with an id of div1 and title of test1</div>
 		<br>
 		<div id="div2" class="blueText">This text is in a div with an id of div2</div>
 		<br>


### PR DESCRIPTION
HTML5 allows arbitrary attributes on elements provided that the attribute begins with "data-". Even before HTML5, this was done by a few people.

Unfortunately, current code will fail, interpreting attribute_value("foo-bar") as "foo - bar".

This has now been fixed and (more importantly) unit tested.

Thank you,
Alan Shields
