### PR TITLE
Use Watir's wait_until

### DIFF
--- a/firewatir/lib/firewatir/firefox.rb
+++ b/firewatir/lib/firewatir/firefox.rb
@@ -981,4 +981,9 @@ module FireWatir
     end
 
   end # Firefox
+
+  # Wait until passed block returns true
+  def wait_until(*args)
+    Watir::Waiter.wait_until(*args) {yield}
+  end
 end # FireWatir

--- a/firewatir/unittests/html/delay.html
+++ b/firewatir/unittests/html/delay.html
@@ -1,0 +1,20 @@
+<HTML>
+<HEAD> 
+<SCRIPT LANGUAGE="JavaScript">
+
+function after_delay_do() {
+  document.getElementById('output').innerHTML = "yes";
+}
+setTimeout(after_delay_do, 400)
+</SCRIPT>
+</HEAD>
+<BODY TEXT="000000" BGCOLOR="FFFFFF">
+<p align="center"> 
+<form>
+
+<div id="output">no</div>
+
+</form>
+</p>
+</BODY>
+</HTML>

--- a/firewatir/unittests/wait_until_test.rb
+++ b/firewatir/unittests/wait_until_test.rb
@@ -1,0 +1,18 @@
+# Rely upon Watir's tests for Waiter, just test accessibility
+
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..') unless $SETUP_LOADED
+require 'unittests/setup'
+
+class TC_WaitUntil < Test::Unit::TestCase
+  def setup
+    goto_page("delay.html")
+  end
+  
+  def test_divs
+    assert(browser.div(:id, "output").verify_contains("no"))
+    assert_nothing_raised do
+      browser.wait_until { browser.div(:id, "output").verify_contains("yes") }
+    end
+    assert(browser.div(:id, "output").verify_contains("yes"))
+  end
+end


### PR DESCRIPTION
Adds wait_until to FireWatir, using commonwatir's implementation.

Unit testing present, though we only verify basic function through Firefox. I leave full testing to Watir's tests, as they are not browser-specific and only deal with mocking.

Thank you,
Alan Shields
