### PR TITLE
Unittest single run

### DIFF
--- a/firewatir/rakefile.rb
+++ b/firewatir/rakefile.rb
@@ -19,3 +19,21 @@ Rake::TestTask.new do |t|
   t.test_files = FileList['unittests/mozilla_all_tests.rb']
   t.verbose = true
 end
+
+# To run a single test form the unittests directory (e.g.
+# unittests/checkbox_test.rb), you can do:
+# rake run_single_test[checkbox_test.rb]
+task :run_single_test, [:test_file] do |t,args|
+  if !args.test_file
+    puts "usage: rake run_single_test[file.rb]"
+    exit
+  end
+
+  require 'unittests/setup'
+  require 'unittests/'+args.test_file
+
+  # usually, when running a single test, i want to be able to look at the browser,
+  # so a dirty hack here is to override the close method on $browser.
+  def $browser.close
+  end
+end

--- a/firewatir/unittests/setup.rb
+++ b/firewatir/unittests/setup.rb
@@ -6,9 +6,12 @@ topdir = File.join(File.dirname(__FILE__), '..')
 $firewatir_dev_lib = File.join(topdir, 'lib')
 $watir_dev_lib = File.join(topdir, '..', 'watir', 'lib')
 commonwatir_dir = "commonwatir#{File.exist?('VERSION') ? "-#{File.read('VERSION').strip}" : ""}"
+
 libs = []
 libs << File.join(topdir, '..', commonwatir_dir, 'lib')
+libs << File.join(topdir, '..', 'commonwatir', 'lib')
 libs << File.join(topdir, '..', commonwatir_dir) # for the unit tests
+libs << File.join(topdir, '..', 'commonwatir')
 libs.each { |lib| $LOAD_PATH.unshift File.expand_path(lib) }
 
 require 'watir/browser'
@@ -21,6 +24,10 @@ end
 require 'unittests/setup/testUnitAddons'
 
 commondir = File.join(topdir, '..', commonwatir_dir)
+if !File.exists?(commondir)
+  commondir = File.join(topdir, '..', "commonwatir")
+end
+
 $all_tests = []
 Dir.chdir topdir do
   $all_tests += Dir["unittests/*_test.rb"]


### PR DESCRIPTION
Talked to charley this morning, and he said there was no easy way to run a single test.

So this diff allows us to easily run a single test.

I'm making two minor changes:
1. firewatir/unittests/setup.rb is adds common watir directory without -version to LOAD_PATH
2. the firewatir rakefile gets a new command to run a single test
