### PR TITLE
Implement Element's methods for frame object and add frames collection

### DIFF
--- a/watir/lib/watir/collections.rb
+++ b/watir/lib/watir/collections.rb
@@ -355,6 +355,15 @@ module Watir
     def element_class; Em; end
     def element_tag; Em::TAG; end
   end
+
+  class Frames < ElementCollections
+    def element_class; Frame; end
+
+    def length
+      @container.document.getElementsByTagName("FRAME").length +
+        @container.document.getElementsByTagName("IFRAME").length
+    end
+  end
   
   class HTMLElements < ElementCollections
     include CommonCollection

--- a/watir/lib/watir/container.rb
+++ b/watir/lib/watir/container.rb
@@ -103,6 +103,18 @@ module Watir
       how, what = process_default :name, how, what
       Frame.new(self, how, what)
     end
+
+    # this is the main method for accessing the frames iterator. Returns a Frames collection
+    #
+    # Typical usage:
+    #
+    #   browser.frames.each { |f| puts f.src }             # iterate through all the frames on the page
+    #   browser.frames[1].to_s                             # goto the first frames on the page
+    #   browser.frames.length                              # show how many frames are on the page.
+    #
+    def frames
+      Frames.new(self)
+    end
         
     # this method is used to access a form.
     # available ways of accessing it are, :index, :name, :id, :method, :action, :xpath

--- a/watir/lib/watir/frame.rb
+++ b/watir/lib/watir/frame.rb
@@ -1,55 +1,38 @@
 module Watir
-  class Frame
-    include Container
+  class Frame < Element
     include PageContainer
-    
+
     # Find the frame denoted by how and what in the container and return its ole_object
     def locate
-      how = @how
-      what = @what
-      frames = @container.document.frames
-      target = nil
-      
-      for i in 0..(frames.length - 1)
-        this_frame = frames.item(i)
-        case how
-        when :index
-          index = i + 1
-          return this_frame if index == what
-        when :name
-          begin
-            return this_frame if what.matches(this_frame.name)
-          rescue # access denied?
-          end
-        when :id
-          # We assume that pages contain frames or iframes, but not both.
-          this_frame_tag = @container.document.getElementsByTagName("FRAME").item(i)
-          return this_frame if this_frame_tag and what.matches(this_frame_tag.invoke("id"))
-          this_iframe_tag = @container.document.getElementsByTagName("IFRAME").item(i)
-          return this_frame if this_iframe_tag and what.matches(this_iframe_tag.invoke("id"))
-        when :src
-          this_frame_tag = @container.document.getElementsByTagName("FRAME").item(i)
-          return this_frame if this_frame_tag and what.matches(this_frame_tag.src)
-          this_iframe_tag = @container.document.getElementsByTagName("IFRAME").item(i) 
-          return this_frame if this_iframe_tag and what.matches(this_iframe_tag.src)
-        else
-          raise ArgumentError, "Argument #{how} not supported"
+      @o = nil
+      locator = FrameLocator.new(@container)
+      locator.set_specifier(@how, @what)
+      ['FRAME', 'IFRAME'].each do |frame_tag|
+        locator.tag = frame_tag
+        located_frame, document = locator.locate
+        unless (located_frame.nil? && document.nil?)
+          @o = located_frame
+          @document = document.document
+          break
         end
-      end
-      
-      raise UnknownFrameException, "Unable to locate a frame with #{how.to_s} #{what}"
+      end      
     end
-    
+
+    def ole_inner_elements
+      document.body.all
+    end
+    private :ole_inner_elements
+
     def initialize(container, how, what)
       set_container container
       @how = how
       @what = what
-      @o = locate
       copy_test_config container
     end
     
     def document
-      @o.document
+      assert_exists
+      @document
     end
 
     def attach_command

--- a/watir/unittests/frame_test.rb
+++ b/watir/unittests/frame_test.rb
@@ -11,43 +11,44 @@ class TC_Frames < Test::Unit::TestCase
   end
 
   def test_frame_no_what
-    assert_raises(UnknownFrameException) { browser.frame("missingFrame").button(:id, "b2").enabled?  }
+    assert_raises(UnknownObjectException) { browser.frame("missingFrame").button(:id, "b2").enabled?  }
     assert_raises(UnknownObjectException) { browser.frame("buttonFrame2").button(:id, "b2").enabled?  }
     assert(browser.frame("buttonFrame").button(:id, "b2").enabled?)
     assert_false(browser.frame("buttonFrame").button(:caption, "Disabled Button").enabled?)
   end
 
   def test_frame_using_name
-    assert_raises(UnknownFrameException) { browser.frame(:name, "missingFrame").button(:id, "b2").enabled?  }
+    assert_raises(UnknownObjectException) { browser.frame(:name, "missingFrame").button(:id, "b2").enabled?  }
     assert_raises(UnknownObjectException) { browser.frame(:name, "buttonFrame2").button(:id, "b2").enabled?  }
     assert(browser.frame(:name, "buttonFrame").button(:id, "b2").enabled?)
     assert_false(browser.frame(:name, "buttonFrame").button(:caption, "Disabled Button").enabled?)
   end
 
   def test_frame_using_name_and_regexp
-    assert_raises(UnknownFrameException) { browser.frame(:name, /missingFrame/).button(:id, "b2").enabled?  }
+    assert_raises(UnknownObjectException) { browser.frame(:name, /missingFrame/).button(:id, "b2").enabled?  }
     assert(browser.frame(:name, /button/).button(:id, "b2").enabled?)
   end
 
   def test_frame_using_index
-    assert_raises(UnknownFrameException) { browser.frame(:index, 8).button(:id, "b2").enabled?  }
+    assert_raises(UnknownObjectException) { browser.frame(:index, 8).button(:id, "b2").enabled?  }
     assert_raises(UnknownObjectException) { browser.frame(:index, 2).button(:id, "b2").enabled?  }
     assert(browser.frame(:index, 1 ).button(:id, "b2").enabled?)
     assert_false(browser.frame(:index, 1).button(:caption, "Disabled Button").enabled?)
+    assert_equal('blankpage.html', browser.frame(:index, 2).src)
   end
 
   tag_method :test_frame_with_invalid_attribute, :fails_on_firefox
 
   def test_frame_with_invalid_attribute
-    assert_raises(ArgumentError) { browser.frame(:blah, 'no_such_thing').button(:id, "b2").enabled?  }
+    assert_raises(MissingWayOfFindingObjectException) { browser.frame(:blah, 'no_such_thing').button(:id, "b2").enabled?  }
   end
 
   def test_preset_frame
     # with ruby's instance_eval, we are able to use the same frame for several actions
     results = browser.frame("buttonFrame").instance_eval do
       [
-              button(:id, "b2").enabled?,
-              button(:caption, "Disabled Button").enabled?
+        button(:id, "b2").enabled?,
+        button(:caption, "Disabled Button").enabled?
       ]
     end
     assert_equal([true, false], results)
@@ -63,11 +64,11 @@ class TC_Frames2 < Test::Unit::TestCase
   end
 
   def test_frame_with_no_name
-    assert_raises(UnknownFrameException) { browser.frame(:name, "missingFrame").button(:id, "b2").enabled?  }
+    assert_raises(UnknownObjectException) { browser.frame(:name, "missingFrame").button(:id, "b2").enabled?  }
   end
 
   def test_frame_by_id
-    assert_raises(UnknownFrameException) { browser.frame(:id, "missingFrame").button(:id, "b2").enabled?  }
+    assert_raises(UnknownObjectException) { browser.frame(:id, "missingFrame").button(:id, "b2").enabled?  }
     assert(browser.frame(:id, 'first_frame').button(:id, "b2").enabled?)
   end
 
@@ -85,8 +86,8 @@ class TC_NestedFrames < Test::Unit::TestCase
   end
 
   def test_frame
-    assert_raises(UnknownFrameException) { browser.frame("missingFrame").button(:id, "b2").enabled?  }
-    assert_raises(UnknownFrameException) { browser.frame("nestedFrame").frame("subFrame").button(:id, "b2").enabled?  }
+    assert_raises(UnknownObjectException) { browser.frame("missingFrame").button(:id, "b2").enabled?  }
+    assert_raises(UnknownObjectException) { browser.frame("nestedFrame").frame("subFrame").button(:id, "b2").enabled?  }
     assert(browser.frame("nestedFrame").frame("senderFrame").button(:name, "sendIt").enabled?)
     browser.frame("nestedFrame").frame("senderFrame").text_field(:index, "1").set("Hello")
     browser.frame("nestedFrame").frame("senderFrame").button(:name, "sendIt").click
@@ -171,3 +172,25 @@ class TC_Frames_click_no_wait < Test::Unit::TestCase
   end
 end
 
+class TC_Frame_multiple_attributes < Test::Unit::TestCase
+  def setup
+    goto_page "frame_multi.html"
+  end
+
+  def test_get_frame_by_name_and_id
+    assert_equal('blankpage.html', browser.frame(:id => 'second_frame', :name => 'buttonFrame2').src)
+  end
+end
+
+class TC_frames_method_for_container < Test::Unit::TestCase
+  def setup
+    goto_page "frame_multi.html"
+  end
+
+  def test_frames_collection
+    frames = browser.frames
+    assert_equal(3, frames.length)
+    assert_equal('first_frame', frames[1].id)
+    assert_equal('pass.html', frames[3].src)
+  end
+end


### PR DESCRIPTION
Hi, Watir team
I've implemented following features:
- Element's methods for frame object like as _exists?_, _name_, _src_ & etc
- Support multiple attribute for frame location
- New method _frames_ for Container and Frames collection class

As I understood following JIRA-tickets can be closed:
 http://jira.openqa.org/browse/WTR-43 <br />
 http://jira.openqa.org/browse/WTR-281

Thanks!
