### PR TITLE
Multiple attribute for Form. Add possibility to use set_no_wait, fire_event_no_wait and other method with no_wait postfix

### DIFF
--- a/watir/lib/watir/collections.rb
+++ b/watir/lib/watir/collections.rb
@@ -364,6 +364,14 @@ module Watir
         @container.document.getElementsByTagName("IFRAME").length
     end
   end
+
+  class Forms < ElementCollections
+    def element_class; Form; end
+    def element_tag; 'FORM'; end
+    def length
+      @container.document.getElementsByTagName("FORM").length
+    end
+  end
   
   class HTMLElements < ElementCollections
     include CommonCollection

--- a/watir/lib/watir/container.rb
+++ b/watir/lib/watir/container.rb
@@ -109,7 +109,7 @@ module Watir
     # Typical usage:
     #
     #   browser.frames.each { |f| puts f.src }             # iterate through all the frames on the page
-    #   browser.frames[1].to_s                             # goto the first frames on the page
+    #   browser.frames[1].to_s                             # goto the first frame on the page
     #   browser.frames.length                              # show how many frames are on the page.
     #
     def frames
@@ -130,6 +130,18 @@ module Watir
       Form.new(self, how, what)
     end
     
+    # this is the main method for accessing the forms iterator. Returns a Forms collection
+    #
+    # Typical usage:
+    #
+    #   browser.forms.each { |f| puts f.src }             # iterate through all the forms on the page
+    #   browser.forms[1].to_s                             # goto the first form on the page
+    #   browser.forms.length                              # show how many forms are on the page.
+    #
+    def forms
+      Forms.new(self)
+    end
+
     # This method is used to get a table from the page.
     # :index (1 based counting) and :id are supported.
     #  NOTE :name is not supported, as the table tag does not have a name attribute. It is not part of the DOM.

--- a/watir/lib/watir/form.rb
+++ b/watir/lib/watir/form.rb
@@ -1,37 +1,35 @@
 module Watir
 
   # Forms
-  
-  module FormAccess
+
+  class FormElement < Element
+    def_wrap_guard :action
+
     def name
-      @ole_object.getAttributeNode('name').value
+      assert_exists
+      @o.getAttributeNode('name').value
     end
-    def action
-      @ole_object.action
+
+    def form_method
+      assert_exists
+      @o.invoke('method')
     end
-    def method
-      @ole_object.invoke('method')
-    end
-    def id
-      @ole_object.invoke('id')
-    end
-  end
-  
-  # wraps around a form OLE object
-  class FormWrapper
-    include FormAccess
-    def initialize ole_object
-      @ole_object = ole_object
+
+    def method(arg = nil)
+      if arg.nil?
+        form_method
+      else
+        super(arg)
+      end
     end
   end
   
   #   Form Factory object
-  class Form < Element
-    include FormAccess
+  class Form < FormElement
     include Container
     
-    attr_accessor :form, :ole_object
-    
+    attr_accessor :form
+
     #   * container   - the containing object, normally an instance of IE
     #   * how         - symbol - how we access the form (:name, :id, :index, :action, :method)
     #   * what        - what we use to access the form
@@ -39,76 +37,41 @@ module Watir
       set_container container
       @how = how
       @what = what
-      
-      log "Get form how is #{@how}  what is #{@what} "
-      
-      # Get form using xpath.
-      if @how == :xpath
-        @ole_object = @container.element_by_xpath(@what)
-      elsif @how == :css
-        @ole_object = @container.element_by_css(@what)
-      else
-        count = 1
-        doc = @container.document
-        doc.forms.each do |thisForm|
-          next unless @ole_object == nil
-          
-          wrapped = FormWrapper.new(thisForm)
-          @ole_object =
-          case @how
-          when :name, :id, :method, :action
-            @what.matches(wrapped.send(@how)) ? thisForm : nil
-          when :index
-            count == @what ? thisForm : nil
-          else
-            raise MissingWayOfFindingObjectException, "#{how} is an unknown way of finding a form (#{what})"
-          end
-          count += 1
-        end
-      end
-      super(@ole_object)
-      
       copy_test_config container
     end
-    
-    def exists?
-      @ole_object ? true : false
-    end
-    alias :exist? :exists?
-    
-    def assert_exists
-      unless exists?
-        raise UnknownFormException, 
-          "Unable to locate a form using #{@how} and #{@what}" 
+
+    def locate
+      log "Get form how is #{@how}  what is #{@what} "
+
+      # Get form using xpath.
+      if @how == :xpath
+        @o = @container.element_by_xpath(@what)
+      elsif @how == :css
+        @o = @container.element_by_css(@what)
+      else
+        locator = FormLocator.new(@container, 'FORM')
+        locator.set_specifier(@how, @what)
+        @o = locator.locate
       end
     end
-    
+
     # Submit the data -- equivalent to pressing Enter or Return to submit a form.
     def submit 
       assert_exists
-      @ole_object.invoke('submit')
+      @o.invoke('submit')
       @container.wait
     end
     
     def ole_inner_elements
       assert_exists
-      @ole_object.elements
+      @o.elements
     end
     private :ole_inner_elements
-    
-    def document
-      return @ole_object
-    end
-    
-    def wait(no_sleep=false)
-      @container.wait(no_sleep)
-    end
-    
+
     # This method is responsible for setting and clearing the colored highlighting on the specified form.
     # use :set  to set the highlight
     #   :clear  to clear the highlight
     def highlight(set_or_clear, element, count)
-      
       if set_or_clear == :set
         begin
           original_color = element.style.backgroundColor
@@ -135,16 +98,17 @@ module Watir
     # causes the object to flash. Normally used in IRB when creating scripts
     # Default is 10
     def flash number=10
+      assert_exists
       @original_styles = {}
       number.times do
         count = 0
-        @ole_object.elements.each do |element|
+        @o.elements.each do |element|
           highlight(:set, element, count)
           count += 1
         end
         sleep 0.05
         count = 0
-        @ole_object.elements.each do |element|
+        @o.elements.each do |element|
           highlight(:clear, element, count)
           count += 1
         end
@@ -154,20 +118,4 @@ module Watir
     
   end # class Form
   
-end
-
-module Watir
-  class Forms < ElementCollections
-    def element_class; Form; end
-    def element_tag; 'FORM'; end
-    def length
-      @container.document.getElementsByTagName("FORM").length
-    end
-  end
-
-  module Container
-    def forms
-      Forms.new(self)
-    end
-  end
 end

--- a/watir/lib/watir/frame.rb
+++ b/watir/lib/watir/frame.rb
@@ -5,17 +5,23 @@ module Watir
     # Find the frame denoted by how and what in the container and return its ole_object
     def locate
       @o = nil
-      locator = FrameLocator.new(@container)
-      locator.set_specifier(@how, @what)
-      ['FRAME', 'IFRAME'].each do |frame_tag|
-        locator.tag = frame_tag
-        located_frame, document = locator.locate
-        unless (located_frame.nil? && document.nil?)
-          @o = located_frame
-          @document = document.document
-          break
+      if @how == :xpath
+        @o = @container.element_by_xpath(@what)
+      elsif @how == :css
+        @o = @container.element_by_css(@what)
+      else      
+        locator = FrameLocator.new(@container)
+        locator.set_specifier(@how, @what)
+        ['FRAME', 'IFRAME'].each do |frame_tag|
+          locator.tag = frame_tag
+          located_frame, document = locator.locate
+          unless (located_frame.nil? && document.nil?)
+            @o = located_frame
+            @document = document.document
+            break
+          end
         end
-      end      
+      end
     end
 
     def ole_inner_elements

--- a/watir/lib/watir/ie-class.rb
+++ b/watir/lib/watir/ie-class.rb
@@ -554,15 +554,14 @@ module Watir
 
     # Show all forms displays all the forms that are on a web page.
     def show_forms
-      if allForms = document.forms
-        count = allForms.length
+      if all_forms = self.forms
+        count = all_forms.length
         puts "There are #{count} forms"
-        for i in 0..count-1 do
-          wrapped = FormWrapper.new(allForms.item(i))
-          puts "Form name: #{wrapped.name}"
-          puts "       id: #{wrapped.id}"
-          puts "   method: #{wrapped.method}"
-          puts "   action: #{wrapped.action}"
+        all_forms.each do |form|
+          puts "Form name: #{form.name}"
+          puts "       id: #{form.id}"
+          puts "   method: #{form.method}"
+          puts "   action: #{form.action}"
         end
       else
         puts "No forms"

--- a/watir/lib/watir/locator.rb
+++ b/watir/lib/watir/locator.rb
@@ -14,6 +14,8 @@ module Watir
           how = :class_name
         when :caption
           how = :value
+        when :method
+          how = :form_method
         end
 
         @specifiers[how] = what
@@ -108,6 +110,14 @@ module Watir
         return element.ole_object, document if count == @specifiers[:index]
       end # elements
       nil
+    end
+  end
+
+  class FormLocator < TaggedElementLocator
+    def each_element(tag)
+      @container.document.forms.each do |form|
+        yield FormElement.new(form)
+      end
     end
   end
 

--- a/watir/unittests/click_no_wait_test.rb
+++ b/watir/unittests/click_no_wait_test.rb
@@ -15,7 +15,7 @@ class ClickNoWait_Tests < Watir::TestCase
   end
 
   def test_spawned_click_no_wait_command
-    assert_equal("start rubyw -e \"some command\"", browser.link(:id => 'link1').send(:__spawned_click_no_wait_command, "some command"))
+    assert_equal("start rubyw -e \"some command\"", browser.link(:id => 'link1').send(:__spawned_no_wait_command, "some command"))
   end
 
 end

--- a/watir/unittests/form_test.rb
+++ b/watir/unittests/form_test.rb
@@ -27,7 +27,12 @@ class TC_Forms2 < Test::Unit::TestCase # Note: there is no TC_Forms1
     assert(browser.form(:action, "pass.html").exists?)   
     assert_false(browser.form(:action, "missing").exists?)   
   end
-  
+
+  def test_multiple_attribute
+    assert_true(browser.form(:name => 'test2', :id => 'f2').exists?)
+    assert_true(browser.form(:name => 'test2', :method => 'get', :action => 'pass2.html'))
+  end
+
   def test_button_in_form
     assert(browser.form(:name, "test2").button(:caption, "Submit").exists?)
   end     
@@ -59,6 +64,19 @@ class TC_Forms2 < Test::Unit::TestCase # Note: there is no TC_Forms1
   end
   def test_form_flash
     assert_nothing_raised{ browser.form(:name, 'test2').flash }
+  end
+end
+
+class TC_Forms_Collection < Test::Unit::TestCase
+  def setup
+    goto_page "forms2.html"
+  end
+
+  def test_forms_collection
+    forms = browser.forms
+    assert_equal(4, forms.length)
+    assert_equal('pass.html', forms.first.action)
+    assert_equal('test2', forms.last.name)
   end
 end
 
@@ -288,3 +306,4 @@ class TC_Hidden_Fields < Test::Unit::TestCase
     assert_equal("hidden_1", browser.hiddens[2].id)
   end
 end
+

--- a/watir/unittests/no_wait_test.rb
+++ b/watir/unittests/no_wait_test.rb
@@ -1,0 +1,22 @@
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', '..') unless $SETUP_LOADED
+require 'unittests/setup'
+
+class TC_No_Wait_Commands < Test::Unit::TestCase
+  def test_fire_event_no_wait
+    goto_page "javascriptevents.html"
+    browser.link(:text, "Check the Status").fire_event_no_wait("onMouseOver")
+    assert_equal("It worked", browser.status) 
+  end
+
+  def test_set_no_wait_text_field
+    goto_page "textfields1.html"
+    browser.text_field(:name, "text1").set_no_wait("watir IE Controller")
+    assert_equal("watir IE Controller", browser.text_field(:name, "text1").value)
+  end
+
+  def test_set_no_wait_text_select_list
+    goto_page "selectboxes1.html"
+    browser.select_list(:name,'sel1').set_no_wait(/Option 1/)
+    assert_equal('Option 1', browser.select_list(:name , 'sel1').selected_options.first)
+  end
+end

--- a/watir/unittests/setup.rb
+++ b/watir/unittests/setup.rb
@@ -71,9 +71,9 @@ $window_tests = Dir["unittests/windows/*_test.rb"] - ["unittests/windows/ie-each
 
 # load development libs also in #click_no_wait processes
 Watir::Element.class_eval do
-  alias_method :__spawned_click_no_wait_command, :spawned_click_no_wait_command
+  alias_method :__spawned_no_wait_command, :spawned_no_wait_command
 
-  def spawned_click_no_wait_command(command)
+  def spawned_no_wait_command(command)
     # make it actually wait in tests for easier testing
     #
     # please note that this implementation of click_no_wait takes considerably more time than


### PR DESCRIPTION
Hi, Watir team again :)

In this commit I've added following features:
- Support of multiple locators #frame method
- Possibility to use _set_, _fire_event_ & etc methods with no_wait postfix

Following JIRA-tickets can be closed:
 http://jira.openqa.org/browse/WTR-144 <br/>
 http://jira.openqa.org/browse/WTR-185
