### PR TITLE
Firefox Binary Location Override

### DIFF
--- a/firewatir/lib/firewatir/firefox.rb
+++ b/firewatir/lib/firewatir/firefox.rb
@@ -923,9 +923,15 @@ module FireWatir
     end
     alias showFrames show_frames
 
+    @@path_to_bin = nil
+    def self.path_to_bin=(path)
+      @@path_to_bin = path
+    end
+
     private
 
     def path_to_bin
+      return @@path_to_bin if @@path_to_bin
       path = case current_os()
              when :windows
                path_from_registry


### PR DESCRIPTION
On my mac with FF 4 installed I needed a way to point my firewatir tests at FF 3.6.9 for jssh to work.  I added a class method to Firefox that sets a class variable that, if populated, uses that value for the path to the Firefox binary instead of deriving it out of spotlight (or whatever other method).

I couldn't find a logical place to put a test of this sort, but I did temporarily hack the mozilla test suite to set the binary to my alternate Firefox and got everything to run just fine manually.
