### PR TITLE
Added code to deleteCookies over jssh

### DIFF
--- a/firewatir/lib/firewatir/firefox.rb
+++ b/firewatir/lib/firewatir/firefox.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 
 module FireWatir
   include Watir::Exception
@@ -185,6 +186,22 @@ module FireWatir
       jssh_command.gsub!(/\n/, "")
       js_eval jssh_command
 
+      # add code for deleting cookies
+      jssh_command = 'var deleteCookies = function (host) {
+  var cookieManager = Components.classes["@mozilla.org/cookiemanager;1"].getService(Components.interfaces.nsICookieManager);
+  var iter = cookieManager.enumerator;
+  while (iter.hasMoreElements()) {
+    var cookie = iter.getNext();
+    if (cookie instanceof Components.interfaces.nsICookie){
+      if (cookie.host.match(host)) {
+        cookieManager.remove(cookie.host, cookie.name, cookie.path, false);
+      }
+    }
+  }
+};'
+      jssh_command.gsub!(/\n/, "")
+      js_eval jssh_command
+
       jssh_command =  "var #{window_var} = getWindows()[#{@window_index}];"
       jssh_command << "var #{browser_var} = #{window_var}.getBrowser();"
       # Add listener create above to browser object
@@ -236,6 +253,13 @@ module FireWatir
         end
 
       end
+    end
+
+    # Delete cookies matching host from the cookie manager in firefox
+    #
+    # ff.delete_cookies('google.com')
+    def delete_cookies(host)
+      js_eval("deleteCookies('#{host}')")
     end
 
     # Closes all firefox windows


### PR DESCRIPTION
I needed to clear the cookies when doing tests in Cucumber, so quickly hacked this XUL method to delete Cookies matching a regexp. I have absolutely no clue about ruby so forgive me if the code is terrible. The javascript can be extended to read out the list of cookies as well:

<pre>function listCookies() {
  var cookieManager = Components.classes["@mozilla.org/cookiemanager;1"].getService(Components.interfaces.nsICookieManager);
  var iter = cookieManager.enumerator;
  while (iter.hasMoreElements()) {
    var cookie = iter.getNext();
    if (cookie instanceof Components.interfaces.nsICookie){
      print("nsiCookie " + cookie.host + " " + cookie.name + " " + cookie.path);
      print("\n");
    }
  }
}
</pre>
