### PR TITLE
Fixed execute_script such that it always returns a value

### DIFF
--- a/firewatir/firewatir.gemspec
+++ b/firewatir/firewatir.gemspec
@@ -39,7 +39,6 @@ spec = Gem::Specification.new do |s|
 
   s.add_dependency 'commonwatir', '>=1.9.2'
 
-  s.has_rdoc = true
   s.rdoc_options <<
       '--title' << 'FireWatir API Reference' <<
   		'--accessor' << 'def_wrap=R,def_wrap_guard=R,def_creator=R,def_creator_with_default=R' <<

--- a/watir/lib/watir/ie-class.rb
+++ b/watir/lib/watir/ie-class.rb
@@ -413,8 +413,16 @@ module Watir
     # Execute the given JavaScript string
     def execute_script(source)
       document.parentWindow.eval(source.to_s)
-    rescue WIN32OLERuntimeError
-      document.parentWindow.execScript(source.to_s)
+    rescue WIN32OLERuntimeError #if eval fails we need to use execScript(source.to_s) which does not return a value, hence the workaround
+      wrapper = "_watir_helper_div_#{rand(100000)}"
+      escaped_src = source.to_s
+      escaped_src = escaped_src.gsub("'", "\\\\'")
+      cmd = "var e= document.createElement('DIV'); e.id='#{wrapper}'; e.innerHTML= eval('#{escaped_src}');document.body.appendChild(e);"
+      document.parentWindow.execScript(cmd)
+      wrapper_obj = document.getElementById(wrapper)
+      result_value = wrapper_obj.innerHTML
+      wrapper_obj.style.display = 'none'
+      result_value
     end
 
     # clear the list of urls that we have visited

--- a/watir/unittests/js_events_test.rb
+++ b/watir/unittests/js_events_test.rb
@@ -23,4 +23,9 @@ class TC_JSEvents < Test::Unit::TestCase
     assert(browser.div(:id, 'event_name').text == 'onchange')
   end
 
+  def test_execute_script
+    assert_equal(browser.execute_script("2+2").to_i, 4)
+    assert_nil(browser.execute_script("null"))
+  end
+
 end

--- a/watir/watir.gemspec
+++ b/watir/watir.gemspec
@@ -41,7 +41,6 @@ spec = Gem::Specification.new do |s|
   s.add_dependency 'ffi', '~>1.0'
   s.add_dependency 'rautomation', '~>0.6.3'
 
-  s.has_rdoc = true
   s.rdoc_options += $WATIR_RDOC_OPTIONS
   s.extra_rdoc_files = $WATIR_EXTRA_RDOC_FILES
   s.executables << 'watir-console'


### PR DESCRIPTION
In few versions of browsers (eg.IE9 on Windows7), where call to eval() fails permanently, it executes js with execScript but returns no result. This commit fixes the behavior. Even though w3c execScript() does not return value, we use it to save value in dom and later return that value. 
