### PR TITLE
Added suport por spanish javascript dialogs and file_field upload 

### DIFF
--- a/watir/lib/watir/dialogs/file_field.rb
+++ b/watir/lib/watir/dialogs/file_field.rb
@@ -21,15 +21,15 @@ module Watir
     end
 
     def open_button
-      file_upload_window.button(:value => '&Open')
+      file_upload_window.button(:value => /&Open|&Abrir/)
     end
 
     def cancel_button
-      file_upload_window.button(:value => 'Cancel')
+      file_upload_window.button(:value => /Cancel/)
     end
 
     def file_upload_window
-      @window ||= RAutomation::Window.new(:title => /^choose file( to upload)?$/i)
+      @window ||= RAutomation::Window.new(:title => /^choose file( to upload)?|Elegir archivos para cargar$/i)
     end
 
   end

--- a/watir/lib/watir/dialogs/javascript.rb
+++ b/watir/lib/watir/dialogs/javascript.rb
@@ -1,7 +1,7 @@
 module Watir
 
   class JavascriptDialog
-    WINDOW_TITLES = ['Message from webpage', 'Windows Internet Explorer','Microsoft Internet Explorer']
+    WINDOW_TITLES = ['Message from webpage', 'Windows Internet Explorer','Microsoft Internet Explorer',/Mensaje de p.*/]
 
     def initialize(opts={})
       @opts = opts


### PR DESCRIPTION
I have a problem with the file_field and javascript dialog, because the titles that watir search are in english, but my office windows system is in spanish.

For example the alter title has the title: Mensaje de página web
http://i53.tinypic.com/29prmvp.png

---
## Mensaje de página web
## Script cargado exitosamente
## Aceptar   

but watir only look for:
WINDOW_TITLES = ['Message from webpage', 'Windows Internet Explorer','Microsoft Internet Explorer']

I modified the options to include the title in spanish without accents
WINDOW_TITLES = ['Message from webpage', 'Windows Internet Explorer','Microsoft Internet Explorer', /Mensaje de p.*/]

The same problem was corrected for file_field upload
