### PR TITLE
 Add HTML5 text field types

### DIFF
--- a/lib/watir-classic/supported_elements.rb
+++ b/lib/watir-classic/supported_elements.rb
@@ -164,7 +164,7 @@ module Watir
     support_element :table
     support_element :tbody, :class => :TableSection
     support_element :td, :tag_name => [:th, :td], :class => :TableCell
-    support_element :text_field, :tag_name => [:text, :password, :textarea], :class => :TextField, :super_class => :InputElement
+    support_element :text_field, :tag_name => [:text, :password, :textarea, :number, :email, :url, :search, :tel], :class => :TextField, :super_class => :InputElement
     support_element :textarea, :class => :TextArea, :super_class => :TextField, :super_collection => :InputElement
     support_element :tfoot, :class => :TableSection
     support_element :th


### PR DESCRIPTION
IE10 and IE11 have support for the input types number, email, url, search and tel.

As a result, they are no longer being found by the text_fields method. This is occurring due to the Watir::Locator#type_matches? method returning false:

````ruby
def type_matches?(el)
  @tags == ["*"] ||
  @tags.include?(el.tagName.downcase) ||
  @tags.include?(el.invoke('type').downcase) rescue false
end
````

When `el.invoke('type').downcase` is called in IE9 for these input types, "text" was returned. As a result, they were found. However, with IE10/IE11 the specific input type (eg "email") is now returned, which is not in the `@tags` array. This change will update the allowed `@tags`.

This will fix Issue #68 