### PR TITLE
Window position and sizing

### DIFF
--- a/lib/watir-classic/window.rb
+++ b/lib/watir-classic/window.rb
@@ -1,5 +1,9 @@
 module Watir
   # Returned by {Browser#window}.
+  
+  Point = Struct.new(:x, :y)
+  Dimension = Struct.new(:width, :height)
+  
   class Window
     include ElementExtensions
 
@@ -91,6 +95,73 @@ module Watir
     end
 
     alias_method :eql?, :==
+
+    #
+    # Returns window size.
+    #
+    # @example
+    # size = browser.window.size
+    # [size.width, size.height] #=> [1600, 1200]
+    #
+
+    def size
+      dimensions = browser.rautomation.dimensions
+      Dimension.new(dimensions[:width], dimensions[:height])
+    end
+
+    #
+    # Returns window position.
+    #
+    # @example
+    # position = browser.window.position
+    # [position.x, position.y] #=> [92, 76]
+    #
+
+    def position
+      dimensions = browser.rautomation.dimensions
+      Point.new(dimensions[:left], dimensions[:top])
+    end
+
+    #
+    # Resizes window to given width and height.
+    #
+    # @example
+    # browser.window.resize_to 1600, 1200
+    #
+    # @param [Fixnum] width
+    # @param [Fixnum] height
+    #
+
+    def resize_to(width, height)
+      browser.rautomation.move(width: width, height: height)
+      size
+    end
+
+    #
+    # Moves window to given x and y coordinates.
+    #
+    # @example
+    # browser.window.move_to 300, 200
+    #
+    # @param [Fixnum] x
+    # @param [Fixnum] y
+    #
+
+    def move_to(x, y)
+      browser.rautomation.move(left: x, top: y)
+      position
+    end
+
+    #
+    # Maximizes window.
+    #
+    # @example
+    # browser.window.maximize
+    #
+
+    def maximize
+      browser.rautomation.maximize
+    end
 
   end
 end


### PR DESCRIPTION
This pull request adds the methods for positioning and sizing a Window as spec'd by the [window_switching_spec](https://github.com/watir/watirspec/blob/aab747291a46c85a92f71601073daab1381c6d91/window_switching_spec.rb#L265-L323). This fixes #54.

Note that the window_switching_spec required modifications to verify that these tests pass. The spec has windows being located using two parameters (how, what) as opposed to a single hash. The window method currently only supports a single parameter, which causes the test failures. An additional pull request will be created to address this other issue.
