### PR TITLE
Ensure unique ID for execute_script helper div.

### DIFF
--- a/lib/watir-classic/page-container.rb
+++ b/lib/watir-classic/page-container.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module Watir
   # A PageContainer contains an HTML Document. In other words, it is a
   # what JavaScript calls a Window.
@@ -24,7 +26,7 @@ module Watir
         result = document.parentWindow.eval(source)
       rescue WIN32OLERuntimeError, NoMethodError #if eval fails we need to use execScript(source.to_s) which does not return a value, hence the workaround
         escaped_src = source.gsub(/\r?\n/, "\\n").gsub("'", "\\\\'")
-        wrapper = "_watir_helper_div_#{::Time.now.to_i + ::Time.now.usec}_#{rand(2**64).to_s(36)}" # ensure unique ID"
+        wrapper = "_watir_helper_div_#{SecureRandom.uuid}"
         cmd = "var e = document.createElement('DIV'); e.style.display='none'; e.id='#{wrapper}'; e.innerHTML = eval('#{escaped_src}'); document.body.appendChild(e);"
         document.parentWindow.execScript(cmd)
         result = document.getElementById(wrapper).innerHTML

--- a/lib/watir-classic/page-container.rb
+++ b/lib/watir-classic/page-container.rb
@@ -24,7 +24,7 @@ module Watir
         result = document.parentWindow.eval(source)
       rescue WIN32OLERuntimeError, NoMethodError #if eval fails we need to use execScript(source.to_s) which does not return a value, hence the workaround
         escaped_src = source.gsub(/\r?\n/, "\\n").gsub("'", "\\\\'")
-        wrapper = "_watir_helper_div_#{::Time.now.to_i + ::Time.now.usec}"
+        wrapper = "_watir_helper_div_#{::Time.now.to_i + ::Time.now.usec}_#{rand(2**64).to_s(36)}" # ensure unique ID"
         cmd = "var e = document.createElement('DIV'); e.style.display='none'; e.id='#{wrapper}'; e.innerHTML = eval('#{escaped_src}'); document.body.appendChild(e);"
         document.parentWindow.execScript(cmd)
         result = document.getElementById(wrapper).innerHTML


### PR DESCRIPTION
Ensure the ID is always unique such that consecutive calls (in the same microsecond) do not return the wrong result.

Issue has been reliably reproduced on Windows 2012 R2 using waitr-classic 4.0.1 to control IE 11.0.9600.17031. When the issue occurs, two consecutive execute_script calls are made, both creating a div with an ID like _watir_helper_div_1433899771. IDs are assumed to be unique, so when retrieving the result, the result stored in the first div is always returned to watir, even though the result in the second div is more recent and the correct result.

<div id="_watir_helper_div_1433395892" style="display: none;">{"value":"default"}</div>
<div id="_watir_helper_div_1433395892" style="display: none;">{"value":45}</div>

In this example, both calls receive "default" as the result, while the second should receive 45.

The patch makes the IDs even more unique with a random string of characters at the end. The new IDs now look like: _watir_helper_div_1433395892_342rg5wh2eb1b