### PR TITLE
Guarantee helper div for execute_script is unique

### DIFF
--- a/lib/watir-classic/page-container.rb
+++ b/lib/watir-classic/page-container.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module Watir
   # A PageContainer contains an HTML Document. In other words, it is a
   # what JavaScript calls a Window.
@@ -24,7 +26,7 @@ module Watir
         result = document.parentWindow.eval(source)
       rescue WIN32OLERuntimeError, NoMethodError #if eval fails we need to use execScript(source.to_s) which does not return a value, hence the workaround
         escaped_src = source.gsub(/\r?\n/, "\\n").gsub("'", "\\\\'")
-        wrapper = "_watir_helper_div_#{::Time.now.to_i + ::Time.now.usec}"
+        wrapper = "_watir_helper_div_#{SecureRandom.uuid}"
         cmd = "var e = document.createElement('DIV'); e.style.display='none'; e.id='#{wrapper}'; e.innerHTML = eval('#{escaped_src}'); document.body.appendChild(e);"
         document.parentWindow.execScript(cmd)
         result = document.getElementById(wrapper).innerHTML


### PR DESCRIPTION
The timestamp based ID for helper div was not always unique, resulting in invalid results from consecutive execute_script calls. SecureRandom.uuid now guarantees a unique value each call.

Issue has been reliably reproduced on Windows 2012 R2 using waitr-classic 4.0.1 to control IE 11.0.9600.17031. When the issue occurs, two consecutive execute_script calls are made, both creating a div with an ID like _watir_helper_div_1433899771. IDs are assumed to be unique, so when retrieving the result, the result stored in the first div is always returned to watir, even though the result in the second div is more recent and the correct result.

{"value":"default"}
{"value":45}
In this example, both calls receive "default" as the result, while the second should receive 45.

The new IDs now look like: _watir_helper_div_b9035027-6a3a-4049-91b4-9495959c98b4

Thanks!
